### PR TITLE
set focus on username input

### DIFF
--- a/modules/luci-base/luasrc/view/sysauth.htm
+++ b/modules/luci-base/luasrc/view/sysauth.htm
@@ -38,7 +38,7 @@
 	</div>
 </form>
 <script type="text/javascript">//<![CDATA[
-	var input = document.getElementsByName('luci_password')[0];
+	var input = document.getElementsByName('luci_username')[0];
 	if (input)
 		input.focus();
 //]]></script>


### PR DESCRIPTION
I've replaced the focus from password to username input in the login page, because of the multi user functionality.
